### PR TITLE
Fix/macos brew owner detection

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -109,7 +109,7 @@ sed_alternative() {
 
 #Get the logged-in user on macOS
 brew_command() {
-    sudo -u "$LOGGED_IN_USER" brew "$@"
+    sudo -u "$LOGGED_IN_USER" -H -i brew "$@"
 }
 
 # Create a temporary directory and ensure it's cleaned up on exit

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -109,7 +109,7 @@ sed_alternative() {
 
 #Get the logged-in user on macOS
 brew_command() {
-    sudo -u "$LOGGED_IN_USER" -H -i brew "$@"
+    sudo -u "$LOGGED_IN_USER" -i brew "$@"
 }
 
 # Create a temporary directory and ensure it's cleaned up on exit

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ NOTIFY_SEND_VERSION=0.8.3
 LOGGED_IN_USER=""
 
 if [ "$(uname -s)" = "Darwin" ]; then
-    LOGGED_IN_USER=$(stat -f '%Su' "$(brew --prefix)")
+    LOGGED_IN_USER=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ {print $3}')
 fi
 
 OS="$(uname -s)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -374,19 +374,27 @@ install_yara_ubuntu() {
 }
 
 install_yara_macos() {
-    info_message "Installing YARA v${YARA_VERSION} from source on macOS" ""
-    YARA_RB_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/5239837c0dc157e5ffdfb2de325e942118db9485/Formula/y/yara.rb" #v4.5.4
-    YARA_RP_PATH="$DOWNLOADS_DIR/yara.rb"
-
-    curl -SL --progress-bar "$YARA_RB_URL" -o "$YARA_RP_PATH" || {
+    info_message "Installing YARA v${YARA_VERSION} from source on macOS"
+    
+    YARA_RB_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/5239837c0dc157e5ffdfb2de325e942118db9485/Formula/y/yara.rb"
+    
+    # Use a location accessible to the target user
+    USER_HOME=$(eval echo "~$LOGGED_IN_USER")
+    YARA_RP_PATH="$USER_HOME/yara.rb"
+    
+    # Download as the target user, not as root
+    info_message "Downloading yara.rb formula..."
+    sudo -u "$LOGGED_IN_USER" curl -SL --progress-bar "$YARA_RB_URL" -o "$YARA_RP_PATH" || {
         error_message "Failed to download yara.rb file"
         exit 1
     }
-
+    
+    # Install using the file in user's home directory
     brew_command install --formula "$YARA_RP_PATH"
     brew_command pin yara
-
-    success_message "YARA v${YARA_VERSION} built and installed from source on macOS successfully"
+    
+    # Clean up
+    sudo -u "$LOGGED_IN_USER" rm -f "$YARA_RP_PATH"
 }
 
 install_yara() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,62 +20,11 @@ TAR_DIR="$DOWNLOADS_DIR/yara-${YARA_VERSION}.tar.gz"
 EXTRACT_DIR="$DOWNLOADS_DIR/yara-${YARA_VERSION}"
 
 NOTIFY_SEND_VERSION=0.8.3
+LOGGED_IN_USER=""
 
-# ---------- Homebrew helpers ----------
-BREW_BIN=""
-BREW_PREFIX=""
-BREW_OWNER=""
-
-init_brew_env() {
-    [ "$(uname -s)" = "Darwin" ] || return 0
-    
-    # Try architecture-specific default first
-    case "$(uname -m)" in
-        arm64) local default_prefix="/opt/homebrew" ;;
-        *)     local default_prefix="/usr/local" ;;
-    esac
-    
-    # Check common locations in order of preference
-    for prefix in "$default_prefix" "/opt/homebrew" "/usr/local"; do
-        if [ -x "$prefix/bin/brew" ]; then
-            BREW_BIN="$prefix/bin/brew"
-            BREW_PREFIX="$prefix"
-            break
-        fi
-    done
-    
-    # If not found, try PATH
-    if [ -z "$BREW_BIN" ]; then
-        local found="$(command -v brew 2>/dev/null || true)"
-        if [ -n "$found" ] && [ -x "$found" ]; then
-            BREW_BIN="$found"
-            BREW_PREFIX="$(dirname "$(dirname "$found")")"
-        fi
-    fi
-    
-    # Determine owner
-    if [ -n "$BREW_PREFIX" ] && [ -d "$BREW_PREFIX" ]; then
-        BREW_OWNER="$(/usr/bin/stat -f '%Su' "$BREW_PREFIX" 2>/dev/null || echo "unknown")"
-    fi
-}
-
-brew_available() {
-    init_brew_env
-    [ -n "$BREW_BIN" ] && [ -x "$BREW_BIN" ] && [ -n "$BREW_OWNER" ] && [ "$BREW_OWNER" != "root" ]
-}
-
-require_brew_or_exit() {
-    if ! brew_available; then
-        error_message "Homebrew not available (or owner undetected). Install Homebrew as a regular user first."
-        exit 1
-    fi
-}
-
-brew_command() {
-    require_brew_or_exit
-    sudo -H -u "$BREW_OWNER" env NONINTERACTIVE=1 PATH="$(dirname "$BREW_BIN"):/usr/bin:/bin:/usr/sbin:/sbin" "$BREW_BIN" "$@"
-}
-# ---------- end Homebrew helpers ----------
+if [ "$(uname -s)" = "Darwin" ]; then
+    LOGGED_IN_USER=$(stat -f '%Su' "$(brew --prefix)")
+fi
 
 OS="$(uname -s)"
 
@@ -88,7 +37,7 @@ elif [ "$OS" = "Darwin" ]; then
     WAZUH_CONTROL_BIN_PATH="/Library/Ossec/bin/wazuh-control"
     YARA_SH_PATH="/Library/Ossec/active-response/bin/yara.sh"
 else
-    echo "Unsupported OS. Exiting..." >&2
+    error_message "Unsupported OS. Exiting..."
     exit 1
 fi
 
@@ -156,6 +105,11 @@ sed_alternative() {
     else
         maybe_sudo sed "$@"
     fi
+}
+
+#Get the logged-in user on macOS
+brew_command() {
+    sudo -u "$LOGGED_IN_USER" brew "$@"
 }
 
 # Create a temporary directory and ensure it's cleaned up on exit
@@ -295,8 +249,8 @@ remove_apt_yara() {
 
 remove_brew_yara() {
     # only on macOS/Homebrew
-    if brew_available; then
-        if brew_command list --formula yara >/dev/null 2>&1; then
+    if command_exists brew; then
+        if brew_command list yara >/dev/null 2>&1; then
             info_message "Removing Homebrew-installed YARA package"
             info_message "Detected Homebrew YARA; uninstalling via brew"
             brew_command uninstall --force yara || {


### PR DESCRIPTION
Key Changes:

- Added -i flag to brew_command() for proper environment isolation
- Download .rb files to user's home directory (/Users/username/) instead of root's (/var/root/)
- User now has proper access to both Homebrew cache and formula files

