### PR TITLE
fix: improve log messages to reflect success and error states for filee operations in yara.sh

### DIFF
--- a/scripts/yara.sh
+++ b/scripts/yara.sh
@@ -205,10 +205,10 @@ send_notification_linux() {
                     echo "wazuh-yara: DEBUG - Attempting to delete file: ${file_path}" >> "${LOG_FILE}"
                     rm -f "${file_path}"
                     if [ $? -eq 0 ]; then
-                        echo "wazuh-yara: INFO - File deleted: ${file_path}" >> "${LOG_FILE}"
+                        echo "wazuh-yara: SUCCESS - Delete file: ${file_path}" >> "${LOG_FILE}"
                         delete_success+=("${file_path}")
                     else
-                        echo "wazuh-yara: ERROR - Failed to delete file: ${file_path}" >> "${LOG_FILE}"
+                        echo "wazuh-yara: ERROR - Delete file: ${file_path}" >> "${LOG_FILE}"
                         delete_fail+=("${file_path}")
                     fi
                 done
@@ -247,10 +247,10 @@ send_notification_linux() {
                 local ignore_fail=()
                 for file_path in "${!detected_files_paths_array_ref}"; do
                     if add_fim_ignore "${file_path}"; then
-                        echo "wazuh-yara: INFO - File ignored in FIM: ${file_path}" >> "${LOG_FILE}"
+                        echo "wazuh-yara: SUCCESS - Ignore file: ${file_path}" >> "${LOG_FILE}"
                         ignore_success+=("${file_path}")
                     else
-                        echo "wazuh-yara: ERROR - Failed to ignore file in FIM: ${file_path}" >> "${LOG_FILE}"
+                        echo "wazuh-yara: ERROR - Ignore file: ${file_path}" >> "${LOG_FILE}"
                         ignore_fail+=("${file_path}")
                     fi
                 done
@@ -337,10 +337,10 @@ send_notification_macos() {
                     echo "wazuh-yara: DEBUG - Attempting to delete file: ${file_path}" >> "${LOG_FILE}"
                     rm -f "${file_path}"
                     if [ $? -eq 0 ]; then
-                        echo "wazuh-yara: INFO - File deleted: ${file_path}" >> "${LOG_FILE}"
+                        echo "wazuh-yara: SUCCESS - Delete file: ${file_path}" >> "${LOG_FILE}"
                         delete_success+=("${file_path}")
                     else
-                        echo "wazuh-yara: ERROR - Failed to delete file: ${file_path}" >> "${LOG_FILE}"
+                        echo "wazuh-yara: ERROR - Delete file: ${file_path}" >> "${LOG_FILE}"
                         delete_fail+=("${file_path}")
                     fi
                 done
@@ -377,10 +377,10 @@ send_notification_macos() {
                 local ignore_fail=()
                 for file_path in "${!detected_files_paths_array_ref}"; do
                     if add_fim_ignore "${file_path}"; then
-                        echo "wazuh-yara: INFO - File ignored in FIM: ${file_path}" >> "${LOG_FILE}"
+                        echo "wazuh-yara: SUCCESS - Ignore file: ${file_path}" >> "${LOG_FILE}"
                         ignore_success+=("${file_path}")
                     else
-                        echo "wazuh-yara: ERROR - Failed to ignore file in FIM: ${file_path}" >> "${LOG_FILE}"
+                        echo "wazuh-yara: ERROR - Ignore file: ${file_path}" >> "${LOG_FILE}"
                         ignore_fail+=("${file_path}")
                     fi
                 done


### PR DESCRIPTION
## Changes

Improve log messages in `yara.sh` to look like the following: 

```
wazuh-yara: SUCCESS - Delete file: /tmp/test file 1.txt
wazuh-yara: ERROR - Delete file: /tmp/test file 1.txt
wazuh-yara: SUCCESS - Ignore file: /tmp/test file 1.txt
wazuh-yara: ERROR - Ignore file: /tmp/test file 1.txt
```

This format eases the creation of decoders and rules to notify of yara operations (actions) on the wazuh dashbaord.

Linked to issue:
- https://github.com/ADORSYS-GIS/wazuh/issues/237

